### PR TITLE
Replace "sanity" with "spot", fix typo

### DIFF
--- a/pa2.ipynb
+++ b/pa2.ipynb
@@ -901,7 +901,7 @@
    },
    "outputs": [],
    "source": [
-    "# Sanity check for logistic_loss()\n",
+    "# Spot check for logistic_loss()\n",
     "check_logistic_loss(logistic_loss)"
    ]
   },
@@ -1090,7 +1090,7 @@
    },
    "outputs": [],
    "source": [
-    "# Sanity check for gradient_descent()\n",
+    "# Spot check for gradient_descent()\n",
     "check_gradient_descent(gradient_descent)"
    ]
   },
@@ -1236,7 +1236,7 @@
     "        TODO: Implement a function to return the trained weights.\n",
     "\n",
     "        Returns:\n",
-    "            np.ndarray: Trained weights, a NumPy array in the sahpe \n",
+    "            np.ndarray: Trained weights, a NumPy array in the shape \n",
     "                (num_features,).\n",
     "        \"\"\"\n",
     "        # CODE START\n",
@@ -1334,7 +1334,7 @@
     "id": "mNcYa1XGKIIG"
    },
    "source": [
-    "### Part 3.2 Sanity Check"
+    "### Part 3.2 Spot Checks"
    ]
   },
   {


### PR DESCRIPTION
Replace "sanity check" with more inclusive term "spot check". See more at https://metaverse-standards.org/diversity-and-inclusion/inclusive-language/#sanity-check.